### PR TITLE
add datatable_options parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ items = forms.ModelMultipleChoiceField(
        enable_shift_select=True,
        enable_datatables=True,
        bootstrap_style=True,
+       datatable_options={'language': {'url': '/foobar.js'}},
     ),
 )
 ```
@@ -51,6 +52,14 @@ If `True`, it inserts JavaScripts, that enables DataTables for the select table.
 Default: `False`
 
 If `True`, it inserts BootStrap classes to the table.
+
+#### `datatable_options`
+Default: `{}`
+
+Dictionary with additional parameters which will be passed to DataTable initialization.
+These options will get formated by `json.dumps`, so it can contain more complex structures.
+Default parameter values set by `DjangoTableSelectMultipleWidget` can be overriden by this parameter.
+
 
 ## Origin
 

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -88,6 +88,22 @@ class TestTableSelectWidget(TestCase):
         render = ChoiceForm().as_p()
         self.assertTrue("$('#choice_field').DataTable({" in render)
 
+    def test_widget_datatables_options(self):
+        """ Test setting additional options """
+        class ChoiceForm(forms.Form):
+            choice_field = forms.ModelMultipleChoiceField(
+                queryset=Choice.objects.all(),
+                widget=TableSelectMultiple(
+                    item_attrs=['name'],
+                    enable_datatables=True,
+                    datatable_options={
+                        'language': {'url': 'foo.js'},
+                    },
+                ),
+            )
+        render = ChoiceForm().as_p()
+        self.assertTrue('"language": {"url": "foo.js"}' in render)
+
     def test_widget_bootstrap(self):
         class ChoiceForm(forms.Form):
             choice_field = forms.ModelMultipleChoiceField(


### PR DESCRIPTION
I added `datatable_options` which allows to set/override `DataTable` initialization options. The options are now set as Python dictionary formatted by `json.dumps`.